### PR TITLE
Default Site Config

### DIFF
--- a/recipes/commons_conf.rb
+++ b/recipes/commons_conf.rb
@@ -64,18 +64,20 @@ cookbook_file "#{node['openresty']['dir']}/conf.d/general_security.inc" do
   mode 00644
 end
 
-template "#{node['openresty']['dir']}/sites-available/default" do
-  source 'default-site.erb'
-  owner 'root'
-  group 'root'
-  mode 00644
-  if ::File.symlink?("#{node['openresty']['dir']}/sites-enabled/000-default")
-    notifies :reload, 'service[nginx]'
+if node['openresty']['default_site_enabled']
+  template "#{node['openresty']['dir']}/sites-available/default" do
+    source 'default-site.erb'
+    owner 'root'
+    group 'root'
+    mode 00644
+    if ::File.symlink?("#{node['openresty']['dir']}/sites-enabled/000-default")
+      notifies :reload, 'service[nginx]'
+    end
   end
-end
 
-openresty_site 'default' do
-  action(node['openresty']['default_site_enabled'] ? :enable : :disable)
+  openresty_site 'default' do
+    action :enable
+  end
 end
 
 if node['openresty']['logrotate']


### PR DESCRIPTION
Issue: If the default site is disabled via node attributes (which it is by default IIRC), then the default site config still gets written to disk and a reload command is sent to the nginx service.

This causes issues in our infrastructure because we have our own cookbook that writes out the default config and reloads nginx on its own. This issue (rendering and reloading the config twice) would have caused the main site to become unavailable in the time between reloads because an incorrect config is in place.

This patch makes it so that config is never written if the default site is disabled via node attributes.
