### PR TITLE
site provider: link for default site is 000-default

### DIFF
--- a/providers/site.rb
+++ b/providers/site.rb
@@ -7,10 +7,11 @@
 
 action :enable do
   timing = [:delayed, :immediately].include?(new_resource.timing) ? new_resource.timing : :delayed
+  link_name = (new_resource.name == "default") ? "000-default" : new_resource.name
   a = execute "nxensite #{new_resource.name}" do
     command "/usr/sbin/nxensite #{new_resource.name}"
     notifies :reload, 'service[nginx]', timing
-    not_if { ::File.symlink?("#{node['openresty']['dir']}/sites-enabled/#{new_resource.name}") }
+    not_if { ::File.symlink?("#{node['openresty']['dir']}/sites-enabled/#{link_name}") }
   end
 
   new_resource.updated_by_last_action(a.updated_by_last_action?)
@@ -18,10 +19,11 @@ end
 
 action :disable do
   timing = [:delayed, :immediately].include?(new_resource.timing) ? new_resource.timing : :delayed
+  link_name = (new_resource.name == "default") ? "000-default" : new_resource.name
   a = execute "nxdissite #{new_resource.name}" do
     command "/usr/sbin/nxdissite #{new_resource.name}"
     notifies :reload, 'service[nginx]', timing
-    only_if { ::File.symlink?("#{node['openresty']['dir']}/sites-enabled/#{new_resource.name}") }
+    only_if { ::File.symlink?("#{node['openresty']['dir']}/sites-enabled/#{link_name}") }
   end
 
   new_resource.updated_by_last_action(a.updated_by_last_action?)    


### PR DESCRIPTION
nxensite and nxdissite rename any site named 'default' to
'000-default' when creating the symlink. This causes a reload
of nginx on every chef-client run when you have a site named
'default'. This patch makes the openresty_site provider aware
of such behavior in nx{en,dis}site.
