### PR TITLE
Remove ‘+’ from the end of a kernel version string

### DIFF
--- a/recipes/commons_build.rb
+++ b/recipes/commons_build.rb
@@ -30,7 +30,7 @@ when 'rhel'
   include_recipe 'yum'
 end
 
-kernel_supports_aio = Chef::VersionConstraint.new('>= 2.6.22').include?(node['kernel']['release'].split('-').first)
+kernel_supports_aio = Chef::VersionConstraint.new('>= 2.6.22').include?(node['kernel']['release'].split('-').first.chomp('+'))
 restart_on_update = node['openresty']['service']['restart_on_update'] ? ' && $( kill -QUIT `pgrep -U root nginx` || true )' : ''
 
 include_recipe 'build-essential'

--- a/recipes/commons_conf.rb
+++ b/recipes/commons_conf.rb
@@ -22,7 +22,7 @@
 
 require 'chef/version_constraint'
 
-kernel_supports_aio = Chef::VersionConstraint.new('>= 2.6.22').include?(node['kernel']['release'].split('-').first)
+kernel_supports_aio = Chef::VersionConstraint.new('>= 2.6.22').include?(node['kernel']['release'].split('-').first.chomp('+'))
 
 if node['openresty']['worker_auto_affinity'] && node['openresty']['worker_processes'] != 'auto'
 


### PR DESCRIPTION
CoreOS does this to indicate that the kernel sources differ from the
official tree.
