### PR TITLE
Guarantee the tarball output directory

### DIFF
--- a/recipes/luarocks.rb
+++ b/recipes/luarocks.rb
@@ -38,11 +38,18 @@ remote_file "#{src_filepath}/#{src_basename}" do
   backup false
 end
 
+directory File.join(src_filepath, src_filename) do
+  owner 'root'
+  group 'root'
+  mode 00755
+  recursive true
+end
+
 execute 'extract-openresty-luarocks' do
-  command "tar xzf #{src_filepath}/#{src_basename}"
+  command "tar -C #{src_filepath}/#{src_filename} --strip-components=1 -xzf #{src_filepath}/#{src_basename}"
   cwd src_filepath
   action :run
-  not_if { ::File.directory?("#{src_filepath}/#{src_filename}") }
+  not_if { ::File.directory?("#{src_filepath}/#{src_filename}") && !Dir["#{src_filepath}/#{src_filename}/*"].empty? }
 end
 
 bash 'compile-openresty-luarocks' do


### PR DESCRIPTION
This allows me to specify the following json:

``` json
{
  "openresty": {
    "luarocks": {
      "version": "2.1.2",
      "url": "https://github.com/keplerproject/luarocks/archive/v2.1.2.tar.gz",
      "checksum": "4dc3fd9ad73cf9b396f98f3b078eaf41f6d7894b6e2b7d05bbff0d8c11484a01"
    }
  }
}
```

Now I can install luarocks again even though luarocks.org is down.

The core issue was that even though the github download url ends in `v2.1.2.tar.gz`, the resulting downloaded file is actually named `luarocks-2.1.2.tar.gz` and creates a directory named `luarocks-2.1.2`.
