### PR TITLE
Make logrotate postrotation script more portable

### DIFF
--- a/recipes/commons_conf.rb
+++ b/recipes/commons_conf.rb
@@ -97,7 +97,7 @@ if node['openresty']['logrotate']
     cookbook 'logrotate'
     create "0644 #{node['openresty']['user']} adm"
     options [ 'missingok', 'delaycompress', 'notifempty', 'compress', 'sharedscripts' ]
-    postrotate "[[ ! -f #{node['openresty']['pid']} ]] || kill -USR1 $(cat #{node['openresty']['pid']})"
+    postrotate "test -f #{node['openresty']['pid']} && kill -USR1 $(cat #{node['openresty']['pid']})"
   end
 
 end


### PR DESCRIPTION
logrotate usually runs postrotate scripts using `/bin/sh`, which does not support `[[ ... ]]` syntax. In result, this happens (at least on Ubuntu 14.04):

```
# test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.daily )
/etc/cron.daily/logrotate:
logrotate_script: 2: logrotate_script: [[: not found
```

`test -f /path/to/pid && kill -USR1 $(cat /path/to/pid)` is more portable.