### PR TITLE
Update mime.types with latest from OpenResty

### DIFF
--- a/files/default/mime.types
+++ b/files/default/mime.types
@@ -2,18 +2,18 @@ types {
     text/html                             html htm shtml;
     text/css                              css;
     text/xml                              xml;
-    text/vcard                            vcf;
     image/gif                             gif;
     image/jpeg                            jpeg jpg;
-    application/x-javascript              js;
-    application/json                      json;
+    application/javascript                js;
     application/atom+xml                  atom;
     application/rss+xml                   rss;
+
     text/mathml                           mml;
     text/plain                            txt;
     text/vnd.sun.j2me.app-descriptor      jad;
     text/vnd.wap.wml                      wml;
     text/x-component                      htc;
+
     image/png                             png;
     image/tiff                            tif tiff;
     image/vnd.wap.wbmp                    wbmp;
@@ -22,13 +22,18 @@ types {
     image/x-ms-bmp                        bmp;
     image/svg+xml                         svg svgz;
     image/webp                            webp;
+
+    application/font-woff                 woff;
     application/java-archive              jar war ear;
+    application/json                      json;
     application/mac-binhex40              hqx;
     application/msword                    doc;
     application/pdf                       pdf;
     application/postscript                ps eps ai;
     application/rtf                       rtf;
+    application/vnd.apple.mpegurl         m3u8;
     application/vnd.ms-excel              xls;
+    application/vnd.ms-fontobject         eot;
     application/vnd.ms-powerpoint         ppt;
     application/vnd.wap.wmlc              wmlc;
     application/vnd.google-earth.kml+xml  kml;
@@ -49,19 +54,27 @@ types {
     application/x-x509-ca-cert            der pem crt;
     application/x-xpinstall               xpi;
     application/xhtml+xml                 xhtml;
+    application/xspf+xml                  xspf;
     application/zip                       zip;
+
     application/octet-stream              bin exe dll;
     application/octet-stream              deb;
     application/octet-stream              dmg;
-    application/octet-stream              eot;
     application/octet-stream              iso img;
     application/octet-stream              msi msp msm;
+
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document    docx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet          xlsx;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation  pptx;
+
     audio/midi                            mid midi kar;
     audio/mpeg                            mp3;
     audio/ogg                             ogg;
     audio/x-m4a                           m4a;
     audio/x-realaudio                     ra;
+
     video/3gpp                            3gpp 3gp;
+    video/mp2t                            ts;
     video/mp4                             mp4;
     video/mpeg                            mpeg mpg;
     video/quicktime                       mov;


### PR DESCRIPTION
This pulls in the updated mime.types file that's part of a default openresty installation: https://github.com/nginx/nginx/blob/master/conf/mime.types

It switches the .js mime type to the more modern application/javascript, and adds support for several other additional file types.