### PR TITLE
Fix symlink to luajit

### DIFF
--- a/attributes/or_modules.rb
+++ b/attributes/or_modules.rb
@@ -22,7 +22,7 @@
 
 # LUAJIT Module
 default['openresty']['or_modules']['luajit']             = true
-default['openresty']['or_modules']['luajit_binary']      = '2.1.0-alpha'
+default['openresty']['or_modules']['luajit_binary']      = '2.1.0-beta1'
 # Iconv Module
 default['openresty']['or_modules']['iconv']              = true
 # Drizzle module


### PR DESCRIPTION
The binary is now `luajit-2.1.0-beta1`

I've just had to fix this by overriding the attribute