### PR TITLE
don't assume luajit is in /usr/share

### DIFF
--- a/recipes/commons_build.rb
+++ b/recipes/commons_build.rb
@@ -197,11 +197,11 @@ bash 'compile_openresty_source' do
   end
 end
 
-link ::File.join('/usr', 'share', 'luajit', 'bin', 'luajit') do
-  to ::File.join('/usr', 'share', 'luajit', 'bin', "luajit-#{node['openresty']['or_modules']['luajit_binary']}")
+link ::File.join("#{node['openresty']['source']['prefix']}", 'bin', 'luajit') do
+  to ::File.join("#{node['openresty']['source']['prefix']}", "luajit-#{node['openresty']['or_modules']['luajit_binary']}")
   only_if do
     node['openresty']['or_modules']['luajit'] &&
-    ::File.exists?(::File.join('/usr', 'share', 'luajit', 'bin', "luajit-#{node['openresty']['or_modules']['luajit_binary']}"))
+    ::File.exists?(::File.join("#{node['openresty']['source']['prefix']}", 'bin', "luajit-#{node['openresty']['or_modules']['luajit_binary']}"))
   end
 end
 


### PR DESCRIPTION
If you were to override the attribute `default['openresty']['source']['prefix']` https://github.com/priestjim/chef-openresty/blob/master/attributes/default.rb#L38 the sym link no longer works for `luajit` because the installation directory for openresty may no longer be `/usr/share`, e.g., I changed it to `/usr/local/openresty` to conform to the official getting started guide: 

This PR uses  `node['openresty']['source']['prefix']` instead of `/usr/share` for creating the symlink to luajit

Could be a related issue: https://github.com/priestjim/chef-openresty/issues/12
