### PR TITLE
link the right directory

### DIFF
--- a/recipes/commons_build.rb
+++ b/recipes/commons_build.rb
@@ -197,11 +197,11 @@ bash 'compile_openresty_source' do
   end
 end
 
-link ::File.join("#{node['openresty']['source']['prefix']}", 'bin', 'luajit') do
-  to ::File.join("#{node['openresty']['source']['prefix']}", "luajit-#{node['openresty']['or_modules']['luajit_binary']}")
+link ::File.join("#{node['openresty']['source']['prefix']}", 'luajit', 'bin', 'luajit') do
+  to ::File.join("#{node['openresty']['source']['prefix']}", 'luajit', 'bin', "luajit-#{node['openresty']['or_modules']['luajit_binary']}")
   only_if do
     node['openresty']['or_modules']['luajit'] &&
-    ::File.exists?(::File.join("#{node['openresty']['source']['prefix']}", 'bin', "luajit-#{node['openresty']['or_modules']['luajit_binary']}"))
+    ::File.exists?(::File.join("#{node['openresty']['source']['prefix']}", 'luajit', 'bin', "luajit-#{node['openresty']['or_modules']['luajit_binary']}"))
   end
 end
 


### PR DESCRIPTION
From this commit: https://github.com/priestjim/chef-openresty/pull/32 I accidentally removed the `luajit` directory from the path. This PR fixes my mistake.

This PR, along with what https://github.com/priestjim/chef-openresty/pull/32 intended to do, fixes the following:

1.) Change your default prefix path, e.g.:  `override['openresty']['source']['prefix'] = '/usr/local/openresty'`
2.) Install a version of openresty older than `1.9.7.1`, e.g., `1.9.3.1` (since `1.9.7.1` installation of openresty handles creation of `luajit` symlink, see discussion here: https://github.com/priestjim/chef-openresty/pull/32)

```
override['openresty']['source']['checksum']  = 'dbcfd21f84431a7d13fe3c3656dcd9dd81236a8f7a114ac8d4afb86665f788bb'
override['openresty']['source']['version']   = '1.9.3.1'
override['openresty']['or_modules']['luajit_binary'] = '2.1.0-alpha'
```

When running the `chef-openresty` recipe, we expect the `luajit` symlink to be created, but it is not, because we cannot assume the prefix is `/usr/share`, it has been changed to `/usr/local/openresty`, and the `luajit-VERSION` binary is now located in `usr/local/openresty/luajit/bin` and NOT `/usr/share/luajit/bin`

NOTE: this also works with the latest `1.9.7.1` openresty installation, since chef `link` will only create the symlink if it doesn't exist already: https://docs.chef.io/resource_link.html