### PR TITLE
Logrotate attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -154,6 +154,7 @@ default['openresty']['open_file_cache'] = {
 
 # Enable default logrotation - disable if you are using something else like AWStats
 default['openresty']['logrotate']                     = true
+default['openresty']['logrotate_days']                = 7
 # Disable general access logging - useful for large scale sites
 default['openresty']['disable_access_log']            = true
 # Enable the default sample vhost config

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -155,6 +155,11 @@ default['openresty']['open_file_cache'] = {
 # Enable default logrotation - disable if you are using something else like AWStats
 default['openresty']['logrotate']                     = true
 default['openresty']['logrotate_days']                = 7
+default['openresty']['logrotate_options'] = [ 'missingok',
+                                              'delaycompress',
+                                              'notifempty',
+                                              'compress',
+                                              'sharedscripts' ]
 # Disable general access logging - useful for large scale sites
 default['openresty']['disable_access_log']            = true
 # Enable the default sample vhost config

--- a/recipes/commons_conf.rb
+++ b/recipes/commons_conf.rb
@@ -103,7 +103,7 @@ if node['openresty']['logrotate']
     path "#{node['openresty']['log_dir']}/*.log"
     enable true
     frequency 'daily'
-    rotate 7
+    rotate node['openresty']['logrotate_days']
     cookbook 'logrotate'
     create "0644 #{node['openresty']['user']} adm"
     options [ 'missingok', 'delaycompress', 'notifempty', 'compress', 'sharedscripts' ]

--- a/recipes/commons_conf.rb
+++ b/recipes/commons_conf.rb
@@ -106,7 +106,7 @@ if node['openresty']['logrotate']
     rotate node['openresty']['logrotate_days']
     cookbook 'logrotate'
     create "0644 #{node['openresty']['user']} adm"
-    options [ 'missingok', 'delaycompress', 'notifempty', 'compress', 'sharedscripts' ]
+    options node['openresty']['logrotate_options']
     postrotate "test -f #{node['openresty']['pid']} && kill -USR1 $(cat #{node['openresty']['pid']})"
   end
 


### PR DESCRIPTION
I need some flexibility in my logrotate options (`dateext` and 30 days). This turn the defaults into attributes.