### PR TITLE
allow using specific path for source/compile location - avoiding transient storage paths.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,11 +21,11 @@
 #
 
 # Download data
-default['openresty']['source']['version']     = '1.9.7.1'
-default['openresty']['source']['file_prefix'] = 'ngx_openresty'
+default['openresty']['source']['version']     = '1.9.7.3'
+default['openresty']['source']['file_prefix'] = 'openresty'
 default['openresty']['source']['name']        = "#{node['openresty']['source']['file_prefix']}-#{node['openresty']['source']['version']}"
 default['openresty']['source']['url']         = "http://agentzh.org/misc/nginx/#{node['openresty']['source']['name']}.tar.gz"
-default['openresty']['source']['checksum']    = '38dfc100d6f1efb7aba0b246f94f04c527f8f51b68be22a8a6579a3ebbbd89e9'
+default['openresty']['source']['checksum']    = '3e4422576d11773a03264021ff7985cd2eeac3382b511ae3052e835210a9a69a'
 
 # Directories
 default['openresty']['dir']                 = '/etc/nginx'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,6 +39,12 @@ default['openresty']['pid']                 = "#{node['openresty']['run_dir']}/n
 default['openresty']['source']['conf_path'] = "#{node['openresty']['dir']}/nginx.conf"
 default['openresty']['source']['prefix']    = '/usr/share'
 
+## extract our source here and compile from this location.
+## by default we use #{Chef::Config['file_cache_path']
+## this allows something more specific since those may be transient and cause recompiles
+default['openresty']['source']['path']    = Chef::Config['file_cache_path']||'/tmp'
+
+
 # Configure flags
 default['openresty']['source']['default_configure_flags'] = [
   "--prefix=#{node['openresty']['source']['prefix']}",

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,9 +21,11 @@
 #
 
 # Download data
-default['openresty']['source']['version']   = '1.9.7.1'
-default['openresty']['source']['url']       = "http://agentzh.org/misc/nginx/ngx_openresty-#{node['openresty']['source']['version']}.tar.gz"
-default['openresty']['source']['checksum']  = '38dfc100d6f1efb7aba0b246f94f04c527f8f51b68be22a8a6579a3ebbbd89e9'
+default['openresty']['source']['version']     = '1.9.7.1'
+default['openresty']['source']['file_prefix'] = 'ngx_openresty'
+default['openresty']['source']['name']        = "#{node['openresty']['source']['file_prefix']}-#{node['openresty']['source']['version']}"
+default['openresty']['source']['url']         = "http://agentzh.org/misc/nginx/#{node['openresty']['source']['name']}.tar.gz"
+default['openresty']['source']['checksum']    = '38dfc100d6f1efb7aba0b246f94f04c527f8f51b68be22a8a6579a3ebbbd89e9'
 
 # Directories
 default['openresty']['dir']                 = '/etc/nginx'

--- a/attributes/fair.rb
+++ b/attributes/fair.rb
@@ -21,5 +21,5 @@
 #
 
 # For more information checkout https://github.com/gnosek/nginx-upstream-fair
-default['openresty']['fair']['url'] 			= 'git://github.com/gnosek/nginx-upstream-fair.git'
+default['openresty']['fair']['url'] 			= 'https://github.com/gnosek/nginx-upstream-fair.git'
 default['openresty']['fair']['name'] 			= 'nginx-upstream-fair'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,9 @@ license           'Apache 2.0'
 description       'Installs and configures the OpenResty NGINX bundle'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md')).chomp
 version           IO.read(File.join(File.dirname(__FILE__), 'VERSION')).chomp rescue '0.1.0'
+chef_version      '>= 11.0'
+issues_url        'https://github.com/priestjim/chef-openresty/issues'
+source_url        'https://github.com/priestjim/chef-openresty'
 
 recipe 'openresty', 'Installs the OpenResty NGINX bundle and sets up configuration with Debian apache style sites-enabled/sites-available'
 
@@ -18,6 +21,5 @@ depends 'ohai', '>= 1.1.4'
 depends 'yum'
 depends 'apt'
 depends 'git'
-
-recommends 'postgresql'
-recommends 'jemalloc'
+depends 'postgresql'
+depends 'jemalloc'

--- a/recipes/cache_purge_module.rb
+++ b/recipes/cache_purge_module.rb
@@ -20,8 +20,8 @@
 #
 
 cpm_src_filename = "ngx_cache_purge-#{::File.basename(node['openresty']['cache_purge']['url'])}"
-cpm_src_filepath = "#{Chef::Config['file_cache_path']}/#{cpm_src_filename}"
-cpm_extract_path = "#{Chef::Config['file_cache_path']}/ngx_cache_purge/#{node['openresty']['cache_purge']['checksum']}"
+cpm_src_filepath = "#{node['openresty']['source']['path']}/#{cpm_src_filename}"
+cpm_extract_path = "#{node['openresty']['source']['path']}/ngx_cache_purge/#{node['openresty']['cache_purge']['checksum']}"
 
 remote_file cpm_src_filepath do
   source node['openresty']['cache_purge']['url']

--- a/recipes/commons_build.rb
+++ b/recipes/commons_build.rb
@@ -35,7 +35,12 @@ restart_on_update = node['openresty']['service']['restart_on_update'] ? ' && $( 
 
 include_recipe 'build-essential'
 
-src_filepath  = "#{Chef::Config['file_cache_path'] || '/tmp'}/#{node['openresty']['source']['name']}.tar.gz"
+directory node['openresty']['source']['path'] do
+  action :create
+  recursive true
+end
+
+src_filepath  = "#{node['openresty']['source']['path']}/#{node['openresty']['source']['name']}.tar.gz"
 
 packages = value_for_platform_family(
   ['rhel','fedora','amazon','scientific'] => [ 'openssl-devel', 'readline-devel', 'ncurses-devel' ],
@@ -64,7 +69,7 @@ node.run_state['openresty_configure_flags'] = node['openresty']['source']['defau
 
 # Custom PCRE
 if node['openresty']['custom_pcre']
-  pcre_path = "#{Chef::Config['file_cache_path'] || '/tmp'}/pcre-#{node['openresty']['pcre']['version']}"
+  pcre_path = "#{node['openresty']['source']['path'] }/pcre-#{node['openresty']['pcre']['version']}"
   pcre_opts = 'export PCRE_CONF_OPT="--enable-utf" && '
   remote_file "#{pcre_path}.tar.bz2" do
     owner 'root'
@@ -76,7 +81,7 @@ if node['openresty']['custom_pcre']
   end
   execute 'openresty-extract-pcre' do
     user 'root'
-    cwd(Chef::Config['file_cache_path'] || '/tmp')
+    cwd(node['openresty']['source']['path'] )
     command "tar xjf #{pcre_path}.tar.bz2"
     not_if { ::File.directory?(pcre_path) }
   end

--- a/recipes/commons_build.rb
+++ b/recipes/commons_build.rb
@@ -35,7 +35,7 @@ restart_on_update = node['openresty']['service']['restart_on_update'] ? ' && $( 
 
 include_recipe 'build-essential'
 
-src_filepath  = "#{Chef::Config['file_cache_path'] || '/tmp'}/ngx_openresty-#{node['openresty']['source']['version']}.tar.gz"
+src_filepath  = "#{Chef::Config['file_cache_path'] || '/tmp'}/#{node['openresty']['source']['name']}.tar.gz"
 
 packages = value_for_platform_family(
   ['rhel','fedora','amazon','scientific'] => [ 'openssl-devel', 'readline-devel', 'ncurses-devel' ],
@@ -95,7 +95,7 @@ end
 # Custom subrequests
 subrequests_file = ::File.join(
   ::File.dirname(src_filepath),
-  "ngx_openresty-#{node['openresty']['source']['version']}",
+  node['openresty']['source']['name'],
   'bundle',
   "nginx-#{node['openresty']['source']['version'].split('.').first(3).join('.')}",
   'src', 'http', 'ngx_http_request.h')
@@ -165,7 +165,7 @@ bash 'compile_openresty_source' do
   cwd ::File.dirname(src_filepath)
   code <<-EOH
     tar zxf #{::File.basename(src_filepath)} -C #{::File.dirname(src_filepath)} &&
-    cd ngx_openresty-#{node['openresty']['source']['version']} &&
+    cd #{node['openresty']['source']['name']} &&
     #{subreq_opts}
     #{pcre_opts}
     ./configure #{node.run_state['openresty_configure_flags'].join(' ')} &&

--- a/recipes/fair_module.rb
+++ b/recipes/fair_module.rb
@@ -21,7 +21,7 @@
 
 include_recipe 'git'
 
-module_path = "#{Chef::Config['file_cache_path']}/#{node['openresty']['fair']['name']}"
+module_path = "#{node['openresty']['source']['path']}/#{node['openresty']['fair']['name']}"
 
 git module_path do
   repository node['openresty']['fair']['url']

--- a/recipes/luarocks.rb
+++ b/recipes/luarocks.rb
@@ -29,7 +29,7 @@ include_recipe 'openresty'
 end
 
 src_basename  = ::File.basename(node['openresty']['luarocks']['url'])
-src_filepath  = Chef::Config['file_cache_path'] || '/tmp'
+src_filepath  = node['openresty']['source']['path']
 src_filename  = ::File.basename(src_basename, '.tar.gz')
 
 remote_file "#{src_filepath}/#{src_basename}" do

--- a/recipes/upload_progress_module.rb
+++ b/recipes/upload_progress_module.rb
@@ -21,8 +21,8 @@
 #
 
 upm_src_filename = ::File.basename(node['openresty']['upload_progress']['url'])
-upm_src_filepath = "#{Chef::Config['file_cache_path']}/#{upm_src_filename}"
-upm_extract_path = "#{Chef::Config['file_cache_path']}/nginx_upload_progress/#{node['openresty']['upload_progress']['checksum']}"
+upm_src_filepath = "#{node['openresty']['source']['path']}/#{upm_src_filename}"
+upm_extract_path = "#{node['openresty']['source']['path']}/nginx_upload_progress/#{node['openresty']['upload_progress']['checksum']}"
 
 remote_file upm_src_filepath do
   source node['openresty']['upload_progress']['url']


### PR DESCRIPTION
create node['openresty']['source']['path'] attribute to allow downloading/compiling into specific location.

Both /tmp and Chef::Config['file_cache_path'] are transient locations -
tmp files may clean up eventually - and at least in my solo environment,
the chef file cache gets replaced for every new revision of the chef
configs.  That means chef recompiles openresty every time that happens..

Leaving the existing behaviors, though, so it doesnt force a recompile
for current users. :)