### PR TITLE
update the nginx-upstream-fair github link from SSH to HTTPS

### DIFF
--- a/attributes/fair.rb
+++ b/attributes/fair.rb
@@ -21,5 +21,5 @@
 #
 
 # For more information checkout https://github.com/gnosek/nginx-upstream-fair
-default['openresty']['fair']['url'] 			= 'git://github.com/gnosek/nginx-upstream-fair.git'
+default['openresty']['fair']['url'] 			= 'https://github.com/gnosek/nginx-upstream-fair.git'
 default['openresty']['fair']['name'] 			= 'nginx-upstream-fair'


### PR DESCRIPTION
can you merge this -
1. Changing the link from SSH to HTTPS as a lot of enterprise won't allow SSH incoming endpoints from external sources. 
2. Since cookbook 3ScaleProxy depends on this cookbook, it fails in enterprise settings.