### PR TITLE
Remove cookbook option from logrotate_app resource

### DIFF
--- a/recipes/commons_conf.rb
+++ b/recipes/commons_conf.rb
@@ -94,7 +94,6 @@ if node['openresty']['logrotate']
     enable true
     frequency 'daily'
     rotate node['openresty']['logrotate_days']
-    cookbook 'logrotate'
     create "0644 #{node['openresty']['user']} adm"
     options node['openresty']['logrotate_options']
     postrotate "test -f #{node['openresty']['pid']} && kill -USR1 $(cat #{node['openresty']['pid']})"


### PR DESCRIPTION
Remove cookbook option from logrotate_app resource. Related: https://github.com/stevendanna/logrotate/commit/78d2fbfe9633dc25b827fe32bd3b1098b74f0e6c#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR14
@priestjim 