### PR TITLE
Support real_ip_recursive directive

### DIFF
--- a/attributes/realip.rb
+++ b/attributes/realip.rb
@@ -23,3 +23,4 @@
 # Currently only accepts X-Forwarded-For or X-Real-IP
 node.default['openresty']['realip']['header']    = 'X-Forwarded-For'
 node.default['openresty']['realip']['addresses'] = ['127.0.0.1']
+node.default['openresty']['realip']['recursive'] = false

--- a/recipes/http_realip_module.rb
+++ b/recipes/http_realip_module.rb
@@ -29,7 +29,8 @@ template "#{node['openresty']['dir']}/conf.d/http_realip.conf" do
   mode 00644
   variables(
     :addresses => node['openresty']['realip']['addresses'],
-    :header => node['openresty']['realip']['header']
+    :header => node['openresty']['realip']['header'],
+    :recursive => node['openresty']['realip']['recursive']
   )
 
   if node['openresty']['service']['start_on_boot']

--- a/templates/default/modules/http_realip.conf.erb
+++ b/templates/default/modules/http_realip.conf.erb
@@ -2,3 +2,4 @@
 set_real_ip_from <%= address %>;
 <% end %>
 real_ip_header <%= @header %>;
+real_ip_recursive <%= @recursive ? 'on' : 'off' %>;


### PR DESCRIPTION
This PR adds support for the real_ip_recursive directive of the realip module, as documented here: http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive