### PR TITLE
Add support for SUSE distros

### DIFF
--- a/attributes/service.rb
+++ b/attributes/service.rb
@@ -21,7 +21,10 @@
 #
 
 # Service recipe for inclusion (can be extra-cookbook)
-default['openresty']['service']['recipe']             = 'openresty::service_init'
+default['openresty']['service']['recipe']             = value_for_platform_family(
+  'suse'    => 'openresty::service_systemd',
+  'default' => 'openresty::service_init',
+)
 # Service resource handler - used for notifications
 default['openresty']['service']['resource']           = 'service[nginx]'
 # Restart automatically after version update

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ source_url        'https://github.com/priestjim/chef-openresty' if respond_to?(:
 
 recipe 'openresty', 'Installs the OpenResty NGINX bundle and sets up configuration with Debian apache style sites-enabled/sites-available'
 
-%w{ ubuntu debian centos redhat amazon scientific oracle fedora }.each do |os|
+%w{ ubuntu debian centos redhat amazon scientific oracle fedora suse opensuseleap }.each do |os|
   supports os
 end
 

--- a/recipes/commons_build.rb
+++ b/recipes/commons_build.rb
@@ -47,12 +47,13 @@ src_filepath  = "#{node['openresty']['source']['path']}/#{src_file_name}.tar.gz"
 
 packages = value_for_platform_family(
   ['rhel','fedora','amazon','scientific'] => ['openssl-devel', 'readline-devel', 'ncurses-devel', 'bzip2'],
+  'suse' => ['libopenssl-devel', 'readline-devel', 'ncurses-devel', 'bzip2'],
   'debian' => ['libperl-dev', 'libssl-dev', 'libreadline-dev', 'libncurses5-dev', 'bzip2']
 )
 
 # Enable AIO for newer kernels
 packages |= value_for_platform_family(
-    ['rhel','fedora','amazon','scientific'] => [ 'libatomic_ops-devel' ],
+    ['rhel','fedora','amazon','scientific','suse'] => [ 'libatomic_ops-devel' ],
     'debian' => [ 'libatomic-ops-dev', 'libaio1', 'libaio-dev' ]
 ) if kernel_supports_aio
 
@@ -92,7 +93,7 @@ if node['openresty']['custom_pcre']
 else
   pcre_opts = ''
   value_for_platform_family(
-    ['rhel','fedora','amazon','scientific'] => [ 'pcre', 'pcre-devel' ],
+    ['rhel','fedora','amazon','scientific','suse'] => [ 'pcre', 'pcre-devel' ],
     'debian' => ['libpcre3', 'libpcre3-dev' ]
   ).each do |pkg|
     package pkg
@@ -140,7 +141,7 @@ end
 
 if node['openresty']['or_modules']['drizzle']
   drizzle = value_for_platform_family(
-    ['rhel','fedora','amazon','scientific'] => 'libdrizzle-devel',
+    ['rhel','fedora','amazon','scientific','suse'] => 'libdrizzle-devel',
     'debian' => 'libdrizzle-dev'
   )
   package drizzle

--- a/recipes/commons_user.rb
+++ b/recipes/commons_user.rb
@@ -21,8 +21,13 @@
 # limitations under the License.
 #
 
+group node['openresty']['group'] do
+  action :create
+end
+
 user node['openresty']['user'] do
   system true
   shell '/bin/false'
   home '/var/www'
+  gid node['openresty']['group']
 end

--- a/recipes/service_init.rb
+++ b/recipes/service_init.rb
@@ -33,7 +33,7 @@ template '/etc/init.d/nginx' do
 end
 
 defaults_path = value_for_platform_family(
-  ['rhel','fedora','amazon','scientific'] => '/etc/sysconfig/nginx',
+  ['rhel','fedora','amazon','scientific','suse'] => '/etc/sysconfig/nginx',
   'debian' => '/etc/default/nginx'
 )
 

--- a/recipes/service_systemd.rb
+++ b/recipes/service_systemd.rb
@@ -1,0 +1,23 @@
+execute 'systemctl daemon-reload' do
+  action :nothing
+end
+
+template '/etc/systemd/system/nginx.service' do
+  source 'nginx.service.erb'
+  owner 'root'
+  group 'root'
+  mode 00644
+  variables(
+    :src_binary => node['openresty']['binary'],
+    :pid => node['openresty']['pid']
+  )
+  notifies :run, 'execute[systemctl daemon-reload]', :immediately
+end
+
+service 'nginx' do
+  provider Chef::Provider::Service::Systemd
+  supports :status => true, :restart => true, :reload => true
+  if node['openresty']['service']['start_on_boot']
+    action [ :enable, :start ]
+  end
+end

--- a/templates/default/nginx.service.erb
+++ b/templates/default/nginx.service.erb
@@ -1,0 +1,17 @@
+[Unit]
+Description=The nginx HTTP and reverse proxy server
+After=network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=forking
+PIDFile=<%= @pid %>
+ExecStartPre=<%= @src_binary %> -t
+ExecStart=<%= @src_binary %>
+ExecReload=/bin/kill -s HUP $MAINPID
+KillMode=process
+KillSignal=SIGQUIT
+TimeoutStopSec=5
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This makes a few tweaks to add support for OpenSUSE and SLES:

- Adjust package dependencies for SUSE.
- Ensure the openresty system group gets created, in addition to the user. In distro's where `USERGROUPS_ENAB` is disabled, the group needs to be explicitly created first, since creating the user account won't automatically create a group with a matching name. (Other cookbooks seem to do this for system accounts, like [postgres](https://github.com/sous-chefs/postgresql/blob/v6.1.1/recipes/server_redhat.rb#L29-L41))
- Add a systemd service script (based on the systemd script from the nginx cookbook).