### PR TITLE
remove include_recipe 'ohai'

### DIFF
--- a/recipes/ohai_plugin.rb
+++ b/recipes/ohai_plugin.rb
@@ -20,8 +20,6 @@
 # limitations under the License.
 #
 
-include_recipe 'ohai'
-
 ohai_plugin 'nginx' do
   source_file 'nginx.rb.erb'
   resource :template


### PR DESCRIPTION
This recipe is empty since ohai 4.0 and triggers a warning.

```
[2017-11-16T09:16:58+00:00] WARN: The Ohai cookbook default recipe has no content as of the 4.0 release. See the readme for instructions on using the custom resources.
```