### PR TITLE
Add missing zlib dependency

### DIFF
--- a/recipes/commons_build.rb
+++ b/recipes/commons_build.rb
@@ -56,7 +56,7 @@ src_filepath  = "#{node['openresty']['source']['path']}/#{src_file_name}.tar.gz"
 packages = value_for_platform_family(
   ['rhel','fedora','amazon','scientific'] => ['openssl-devel', 'readline-devel', 'ncurses-devel', 'bzip2'],
   'suse' => ['libopenssl-devel', 'readline-devel', 'ncurses-devel', 'bzip2'],
-  'debian' => ['libperl-dev', 'libssl-dev', 'libreadline-dev', 'libncurses5-dev', 'bzip2']
+  'debian' => ['libperl-dev', 'libssl-dev', 'libreadline-dev', 'libncurses5-dev', 'bzip2', 'zlib1g-dev']
 )
 
 # Enable AIO for newer kernels


### PR DESCRIPTION
The compilation requires `zlib.h` which is provided by the `zlib1g-dev` package.

(Debian 9)