### PR TITLE
Specify multiple error_log paths

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -161,6 +161,9 @@ default['openresty']['open_file_cache'] = {
   'errors'    => 'on'
 }
 
+default['openresty']['error_log'] = [
+  "#{node['openresty']['log_dir']}/error.log"
+]
 default['openresty']['log_formats'] = { main: '$remote_addr - $remote_user [$time_local] "$request" ' \
                                               '$status $body_bytes_sent "$http_referer" ' \
                                               '"$http_user_agent" "$http_x_forwarded_for"' }

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -8,7 +8,9 @@ worker_cpu_affinity <%= node['openresty']['worker_cpu_affinity'] %>;
 worker_rlimit_nofile <%= node['openresty']['worker_rlimit_nofile'] %>;
 <% end -%>
 
-error_log  <%= node['openresty']['log_dir'] %>/error.log;
+<% node['openresty']['error_log'].each do |path| %>
+error_log <%= path %>;
+<% end %>
 pid        <%= node['openresty']['pid'] %>;
 
 events {


### PR DESCRIPTION
This is needed in cases like:
```
error_log syslog:server=127.0.0.1:5140
error_log /dev/null;
```