### PR TITLE
Adding more configurability to enable this cookbook over vagrant and to be wrapped.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -99,6 +99,9 @@ else
 end
 
 default['openresty']['group']         = node['openresty']['user']
+default['openresty']['user_system']   = true
+default['openresty']['user_shell']    = '/bin/false'
+default['openresty']['user_home']     = '/var/www'
 
 if node['os'].eql?('linux') && (node['network']['interfaces']['lo']['addresses'].include?('::1') rescue false)
   default['openresty']['ipv6'] = true
@@ -136,6 +139,8 @@ default['openresty']['worker_auto_affinity']          = true
 default['openresty']['worker_connections']            = 4096
 default['openresty']['worker_rlimit_nofile']          = nil
 default['openresty']['multi_accept']                  = false
+
+default['openresty']['try_aio']                       = true
 
 # epoll is available only on Linux kernels >= 2.6
 if node['os'].eql?('linux') && node['kernel']['release'].to_f >= 2.6

--- a/providers/site.rb
+++ b/providers/site.rb
@@ -30,6 +30,7 @@ action :enable do
       group 'root'
       mode 00644
       variables new_resource.variables
+      cookbook new_resource.cookbook
       if node['openresty']['service']['start_on_boot']
         notifies :reload, node['openresty']['service']['resource'], new_resource.timing
       end

--- a/recipes/commons_user.rb
+++ b/recipes/commons_user.rb
@@ -26,8 +26,8 @@ group node['openresty']['group'] do
 end
 
 user node['openresty']['user'] do
-  system true
-  shell '/bin/false'
-  home '/var/www'
+  system node['openresty']['user_system']
+  shell node['openresty']['user_shell']
+  home node['openresty']['user_home']
   gid node['openresty']['group']
 end

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -26,4 +26,5 @@ default_action :enable
 attribute :name, :kind_of => String, :name_attribute => true
 attribute :template, :kind_of => String, :default => nil
 attribute :variables, :kind_of => Hash, :default => {}
+attribute :cookbook, :kind_of => String, :default => nil
 attribute :timing, [:delayed, :immediately], :default => :delayed

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -29,7 +29,7 @@ http {
   access_log	<%= node['openresty']['log_dir'] %>/access.log;
   <% end %>
 
-  <% if @kernel_supports_aio %>
+  <% if @kernel_supports_aio  && node['openresty']['try_aio'] %>
   sendfile off;
   aio on;
   directio 512;


### PR DESCRIPTION
 Can now specify the cookbook that your site template will reside in which is helpful for wrapper cookbooks. Can also configure more details about the user openresty creates which was necessary based on the existing cookbook for when you want to use the vagrant user in a dev environment. Also made aio configurable for situations where aio is supported by the kernel, but not the filesystem (an issue with virtualbox and shared folders.) All values default to the original values so should be backwards compatible for users without the new configurable parameters.