### PR TITLE
Upgrade openresty-1.15.8.2

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,6 +5,7 @@ driver:
 provisioner:
   name: chef_solo
   log_level: info
+  chef_license: accept
 
 platforms:
   - name: ubuntu-16.04-chef-12

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
-site :opscode
+source 'https://supermarket.chef.io'
 
 metadata
+
+cookbook 'seven_zip', '< 3.0.0'

--- a/attributes/custom_pcre.rb
+++ b/attributes/custom_pcre.rb
@@ -20,6 +20,6 @@
 # limitations under the License.
 #
 
-default['openresty']['pcre']['version']  = '8.41'
+default['openresty']['pcre']['version']  = '8.43'
 default['openresty']['pcre']['url']      = "https://sourceforge.net/projects/pcre/files/pcre/#{node['openresty']['pcre']['version']}/pcre-#{node['openresty']['pcre']['version']}.tar.bz2/download"
-default['openresty']['pcre']['checksum'] = 'e62c7eac5ae7c0e7286db61ff82912e1c0b7a0c13706616e94a7dd729321b530'
+default['openresty']['pcre']['checksum'] = '91e762520003013834ac1adb4a938d53b22a216341c061b0cf05603b290faf6b'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,9 +21,9 @@
 #
 
 # Download data
-default['openresty']['source']['version']     = '1.13.6.2'
+default['openresty']['source']['version']     = '1.15.8.2'
 default['openresty']['source']['file_prefix'] = 'openresty'
-default['openresty']['source']['checksum']    = '946e1958273032db43833982e2cec0766154a9b5cb8e67868944113208ff2942'
+default['openresty']['source']['checksum']    = '436b4e84d547a97a18cf7a2522daf819da8087b188468946b5a89c0dd1ca5d16'
 #use %{} for delayed interpolation
 default['openresty']['source']['name']        = "%{file_prefix}-%{version}"
 default['openresty']['source']['url']         = "https://openresty.org/download/%{name}.tar.gz"

--- a/attributes/luarocks.rb
+++ b/attributes/luarocks.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-default['openresty']['luarocks']['version']       = '2.4.2'
+default['openresty']['luarocks']['version']       = '3.2.1'
 default['openresty']['luarocks']['url']           = "http://luarocks.org/releases/luarocks-#{node['openresty']['luarocks']['version']}.tar.gz"
-default['openresty']['luarocks']['checksum']      = '0e1ec34583e1b265e0fbafb64c8bd348705ad403fe85967fd05d3a659f74d2e5'
+default['openresty']['luarocks']['checksum']      = 'f27e20c9cdb3ffb991ccdb85796c36a0690566676f8e1a59b0d0ee6598907d04'
 default['openresty']['luarocks']['default_rocks'] = Hash.new

--- a/attributes/or_modules.rb
+++ b/attributes/or_modules.rb
@@ -22,7 +22,7 @@
 
 # LUAJIT Module
 default['openresty']['or_modules']['luajit']             = true
-default['openresty']['or_modules']['luajit_binary']      = '2.1.0-beta1'
+default['openresty']['or_modules']['luajit_binary']      = '2.1.0-beta3'
 # Iconv Module
 default['openresty']['or_modules']['iconv']              = true
 # Drizzle module


### PR DESCRIPTION
This PR does the following:

- Upgrade default OpenResty version to 1.15.8.2
- Upgrade PCRE library to 8.43
- Upgrade luarocks to 3.2.1
- Update symlink to luajit binary for new LUAJIT version
- Fix Berksfile supermarket source
- Pin `seven_zip` to < 3.0.0 for chef-client 12 ( >= 3.0.0 requires chef-client 13)
- Accept the Chef license during kitchen run for chef-latest suites
